### PR TITLE
nightly builds + minor other

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# rpm backups
+rpm/*.spec.20*
+
+# vim tmp files
+.*.sw?
+
+log.txt
+diffs/
+translations.old/
+translations.old.bak/
+
+rpmbuild/
+release_rpms/
+

--- a/README.md
+++ b/README.md
@@ -12,55 +12,72 @@ Building an RPM requires the following things:
 
 RPM build process:
 // all commands executed from the checked out folder
-export POOTLE_LANG=langcode; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=langcode; export QM_SUFFIX=langcode; ./tools/createqm.sh 
-export LANGCODE=langcode; ./tools/createrpm.sh 
+export POOTLE_LANG=langcode QM_SUFFIX=langcode LANGCODE=langcode
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
 You can additionally install the package with the ./tools/install_on_device.sh. The script requires to have the jolla DNS name to be resolved to your device's address. 
 
 If you would like to create a package for a new language please let me know with an issue or a PR.
 
 For hungarian
-export POOTLE_LANG=hu; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=hu; export QM_SUFFIX=hu; ./tools/createqm.sh 
-export LANGCODE=hu; ./tools/createrpm.sh 
+export POOTLE_LANG=hu QM_SUFFIX=hu LANGCODE=hu
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=nl; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=nl; export QM_SUFFIX=nl; ./tools/createqm.sh 
-export LANGCODE=nl; ./tools/createrpm.sh 
+export POOTLE_LANG=nl QM_SUFFIX=nl LANGCODE=nl
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=zh_TW; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=zh_TW; export QM_SUFFIX=zh_TW; ./tools/createqm.sh 
-export LANGCODE=zh_TW; ./tools/createrpm.sh 
+export POOTLE_LANG=zh_TW QM_SUFFIX=zh_TW LANGCODE=zh_TW
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=el; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=el; export QM_SUFFIX=el; ./tools/createqm.sh 
-export LANGCODE=el; ./tools/createrpm.sh 
+export POOTLE_LANG=el QM_SUFFIX=el LANGCODE=el
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=sl; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=sl; export QM_SUFFIX=sl; ./tools/createqm.sh 
-export LANGCODE=sl; ./tools/createrpm.sh 
+export POOTLE_LANG=sl QM_SUFFIX=sl LANGCODE=sl
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=ja; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=ja; export QM_SUFFIX=ja; ./tools/createqm.sh 
-export LANGCODE=ja; ./tools/createrpm.sh 
+export POOTLE_LANG=ja QM_SUFFIX=ja LANGCODE=ja
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=ko; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=ko; export QM_SUFFIX=ko; ./tools/createqm.sh 
-export LANGCODE=ko; ./tools/createrpm.sh 
+export POOTLE_LANG=ko QM_SUFFIX=ko LANGCODE=ko
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=ca; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=ca; export QM_SUFFIX=ca; ./tools/createqm.sh 
-export LANGCODE=ca; ./tools/createrpm.sh 
+export POOTLE_LANG=ca QM_SUFFIX=ca LANGCODE=ca
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=pt_BR; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=pt_BR; export QM_SUFFIX=pt_BR; ./tools/createqm.sh 
-export LANGCODE=pt_BR; ./tools/createrpm.sh 
+export POOTLE_LANG=pt_BR QM_SUFFIX=pt_BR LANGCODE=pt_BR
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=et; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=et; export QM_SUFFIX=et; ./tools/createqm.sh 
-export LANGCODE=et; ./tools/createrpm.sh 
+export POOTLE_LANG=et QM_SUFFIX=et LANGCODE=et
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
 
-export POOTLE_LANG=tr; ./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
-export POOTLE_LANG=tr; export QM_SUFFIX=tr; ./tools/createqm.sh 
-export LANGCODE=tr; ./tools/createrpm.sh
+export POOTLE_LANG=tr QM_SUFFIX=tr LANGCODE=tr
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh
+
+export POOTLE_LANG=bg QM_SUFFIX=bg LANGCODE=bg
+./tools/fetchts.sh # this will take a while because it downloads the ts files from Pootle
+./tools/createqm.sh
+./tools/createrpm.sh

--- a/tools/createrpm.sh
+++ b/tools/createrpm.sh
@@ -7,7 +7,17 @@
 #
 ##############################################
 
-SAVEDIR=$HOME/release_rpms
+SAVEDIR=$PWD/release_rpms
+if [ ! -e "$SAVEDIR" ]
+then
+    echo creating "$SAVEDIR"...
+    mkdir "$SAVEDIR"
+elif [ ! -d "$SAVEDIR" ]
+then
+    echo "$SAVEDIR is not a dir"
+    exit -1
+fi
+
 if [ -z $LANGCODE ] 
 then
     echo "The LANGCODE variable is not set!"

--- a/tools/install_on_device.sh
+++ b/tools/install_on_device.sh
@@ -4,4 +4,4 @@ RPMDIR="$HOME/rpmbuild/RPMS/noarch"
 RPMFILE=`ls $RPMDIR -tp | grep -v /$ | head -1`
 DEVADDRESS=af # added to /etc/hosts
 scp $RPMDIR/$RPMFILE nemo@$DEVADDRESS:/tmp
-ssh nemo@$DEVADDRESS "pkcon -y install-local /tmp/$RPMFILE"
+ssh nemo@$DEVADDRESS "devel-su pkcon -y install-local /tmp/$RPMFILE"

--- a/tools/nightly_build.sh
+++ b/tools/nightly_build.sh
@@ -1,0 +1,109 @@
+#!/bin/dash
+
+log() {
+	>>log.txt echo "$@"
+}
+
+we=`basename $0`
+
+usage() {
+	[ -n "$1" ] && echo $we: $@
+	cat <<.
+	$we:
+
+	this script builds a new package if there are differences in the
+	translation compared to the last time it had built a package. It
+	automatically increases minor version numbers for new builds,
+	generates diffs and publishes both diffs and packages to the
+	configured destination.
+
+	The resulting target directory may look like this after running
+	it 3 times:
+
+	diffs/
+	latest.rpm
+	log.txt
+	unofficial-jolla-language-pack-bg-2.1.2-0.0.1.noarch.rpm
+	unofficial-jolla-language-pack-bg-2.1.2-0.0.2.noarch.rpm
+	unofficial-jolla-language-pack-bg-2.1.2-0.0.3.noarch.rpm
+	...
+
+
+	Usage:
+	% export lang=bg maintainer=omkpuBamev uploadsrvr=example.com uploadpath=websites/public/sailfish
+	% $we
+
+	Example invocation as cronjob every night at 1:30am:
+	30      1      *       *       *       lang=bg maintainer=omkpuBamev uploadsrvr=example.com uploadpath=websites/public/sailfish /home/omkpuBamev/repos/unofficial-jolla-translation/tools/nightly_build.sh
+.
+	exit 1
+}
+
+# make sure vars we expect are set
+[ -n "$lang" ] || usage "lang not set"
+[ -n "$maintainer" ] || usage "maintainer not set"
+[ -n "$uploadsrvr" ] || usage "uploadsrvr not set"
+[ -n "$uploadpath" ] || usage "uploadpath not set"
+
+# conf
+export POOTLE_LANG=$lang QM_SUFFIX=$lang LANGCODE=$lang
+spec=rpm/unofficial-jolla-language-pack-$lang.spec
+upload=$uploadsrvr:$uploadpath
+echo using "
+	spec: $spec
+	maintainer: $maintainer
+	upload: $upload
+"
+this=`realpath $0`
+thisdir=`dirname $this`
+
+# go to one above tools/
+cd $thisdir
+cd ..
+
+# get new version from file
+lastver=`sed -n "/^Release:/ { s/Release:\s*//; p}" $spec`
+lastnum=`echo $lastver | cut -d. -f3`
+newnum=$(($lastnum + 1))
+majorminor=`echo $lastver | cut -d. -f1,2`
+newver=$majorminor.$newnum
+
+ts=`date +%FT%T`
+log running $ts
+echo "last: $lastver"
+echo "new:  $newver"
+
+rm -rf translations.old.bak
+mv translations.old translations.old.bak
+cp -r translations/ translations.old
+
+echo doing... ./tools/fetchts.sh
+./tools/fetchts.sh
+
+# found diffs?
+mkdir diffs
+difffile=diffs/$ts.diff
+changelog=`date +"%a %b %d %Y"`" "$maintainer
+if diff -r -u translations.old translations > $difffile
+then
+	echo "no differences found"
+	log "no differences found"
+	exit 0
+else
+	read -p "create new package? <ctrl-c> to brake | <enter> to continue" usrinput
+	log "creating new package: $newver"
+	sed -i.$ts "
+		/^Release:/ s/$lastver/$newver/
+		/%changelog/ a * $changelog
+		/%changelog/ a - nightly. changes: $difffile
+	" $spec
+	./tools/createqm.sh
+	./tools/createrpm.sh
+	echo rsync releases and diffs to $upload/ ...
+	rsync -rav --progress release_rpms/ $upload
+	rsync -rav --progress diffs $upload
+	ssh $uploadsrvr "cd $uploadpath;"' l=`ls -t *.rpm | sed 1q`;  ln -s -f $l latest.rpm'
+	log "done."
+fi
+
+rsync -rav --progress log.txt $upload


### PR DESCRIPTION
I needed to fix a few minor things in order the tool chain to work for me, e.g. pkcon didn't install without super user rights on the device.

The second thing is a script I wrote to automate the creation of nightly builds and tracking the differences between them. IMO this was quite useful for us. The script uses the existing scripts to download the current translations and package them. It compares the translations against the ones it downloaded the last time it was invoked and if there are differences creates a new package. In such case, it counts one up from the last published version. The package is uploaded (`ssh`/`rsync`) to the configured server together with the diff to the previous version and is symlinked as the `latest.rpm`.  See the `usage()` function for example dir structure on the target server.

I ran this as a cron job nightly and it proved useful and stable for the past few weeks. Might be useful for others too. 